### PR TITLE
Schema Refactor: change overstocked to does_repairs

### DIFF
--- a/db/migrate/20220324190833_change_column_name.rb
+++ b/db/migrate/20220324190833_change_column_name.rb
@@ -1,0 +1,5 @@
+class ChangeColumnName < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :game_shops, :overstocked, :does_repairs
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_23_215335) do
+ActiveRecord::Schema.define(version: 2022_03_24_190833) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "game_shops", force: :cascade do |t|
     t.string "name"
-    t.boolean "overstocked"
+    t.boolean "does_repairs"
     t.integer "stock_limit"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false


### PR DESCRIPTION
the overstocked attribute was something that depended on the amount of games associated with each shop - because that is related to business logic, and we are not doing any of that in this project, i changed it to a more independent attribute called does_repairs