### PR TITLE
Game shop page shows game count

### DIFF
--- a/app/models/game_shop.rb
+++ b/app/models/game_shop.rb
@@ -2,4 +2,8 @@ class GameShop < ApplicationRecord
   has_many :video_games
   validates_presence_of :name, :stock_limit
   validates_inclusion_of :does_repairs, in: [true, false]
+
+  def total_games_in_stock
+    self.video_games.count
+  end
 end

--- a/app/views/game_shops/show.html.erb
+++ b/app/views/game_shops/show.html.erb
@@ -5,3 +5,4 @@
 <p>Does repairs: <%= @shop.does_repairs %></p>
 <p>Created at: <%= @shop.created_at %></p>
 <p>Updated at: <%= @shop.updated_at %></p>
+<p>Games sold: <%= @shop.total_games_in_stock %> </p>

--- a/spec/features/game_shop/show_spec.rb
+++ b/spec/features/game_shop/show_spec.rb
@@ -4,26 +4,26 @@ RSpec.describe 'GameShops', type: :feature do
   before :each do
     @shop1 = GameShop.create!(name: "Fred's Games", does_repairs: false, stock_limit: 3)
     @shop2 = GameShop.create!(name: "Gameville", does_repairs: false, stock_limit: 5)
-    @game1 = shop1.video_games.create!(name: "DOOM 2016", rating: "M", price: 70, multiplayer: false)
-    @game2 = shop1.video_games.create!(name: "FIFA 2020", rating: "E", price: 55, multiplayer: true)
-    @game3 = shop2.video_games.create!(name: "Elden Ring", rating: "M", price: 65, multiplayer: true)
+    @game1 = @shop1.video_games.create!(name: "DOOM 2016", rating: "M", price: 70, multiplayer: false)
+    @game2 = @shop1.video_games.create!(name: "FIFA 2020", rating: "E", price: 55, multiplayer: true)
+    @game3 = @shop2.video_games.create!(name: "Elden Ring", rating: "M", price: 65, multiplayer: true)
   end
 
   context '#show' do
     it 'displays the matching GameShop and attibutes' do
-      visit "/game_shops/#{shop1.id}"
+      visit "/game_shops/#{@shop1.id}"
 
-      expect(page).to have_content("ID: #{shop1.id}")
-      expect(page).to have_content(shop1.name)
-      expect(page).to have_content("Does repairs: #{shop1.does_repairs}")
-      expect(page).to have_content("Stock limit: #{shop1.stock_limit}")
-      expect(page).to have_content("Created at: #{shop1.created_at}")
-      expect(page).to have_content("Updated at: #{shop1.updated_at}")
-      expect(page).to have_content("Games sold: #{shop1.games_sold}")
+      expect(page).to have_content("ID: #{@shop1.id}")
+      expect(page).to have_content(@shop1.name)
+      expect(page).to have_content("Does repairs: #{@shop1.does_repairs}")
+      expect(page).to have_content("Stock limit: #{@shop1.stock_limit}")
+      expect(page).to have_content("Created at: #{@shop1.created_at}")
+      expect(page).to have_content("Updated at: #{@shop1.updated_at}")
+      expect(page).to have_content("Games sold: 2")
 
-      expect(page).to_not have_content("ID: #{shop2.id}")
-      expect(page).to_not have_content(shop2.name)
-      expect(page).to_not have_content("Stock limit: #{shop2.stock_limit}")
+      expect(page).to_not have_content("ID: #{@shop2.id}")
+      expect(page).to_not have_content(@shop2.name)
+      expect(page).to_not have_content("Stock limit: #{@shop2.stock_limit}")
     end
 
   end

--- a/spec/features/game_shop/show_spec.rb
+++ b/spec/features/game_shop/show_spec.rb
@@ -1,11 +1,16 @@
 require 'rails_helper'
 
 RSpec.describe 'GameShops', type: :feature do
+  before :each do
+    @shop1 = GameShop.create!(name: "Fred's Games", does_repairs: false, stock_limit: 3)
+    @shop2 = GameShop.create!(name: "Gameville", does_repairs: false, stock_limit: 5)
+    @game1 = shop1.video_games.create!(name: "DOOM 2016", rating: "M", price: 70, multiplayer: false)
+    @game2 = shop1.video_games.create!(name: "FIFA 2020", rating: "E", price: 55, multiplayer: true)
+    @game3 = shop2.video_games.create!(name: "Elden Ring", rating: "M", price: 65, multiplayer: true)
+  end
+
   context '#show' do
     it 'displays the matching GameShop and attibutes' do
-      shop1 = GameShop.create!(name: "Fred's Games", does_repairs: false, stock_limit: 3)
-      shop2 = GameShop.create!(name: "Gameville", does_repairs: false, stock_limit: 5)
-
       visit "/game_shops/#{shop1.id}"
 
       expect(page).to have_content("ID: #{shop1.id}")
@@ -14,10 +19,12 @@ RSpec.describe 'GameShops', type: :feature do
       expect(page).to have_content("Stock limit: #{shop1.stock_limit}")
       expect(page).to have_content("Created at: #{shop1.created_at}")
       expect(page).to have_content("Updated at: #{shop1.updated_at}")
+      expect(page).to have_content("Games sold: #{shop1.games_sold}")
 
       expect(page).to_not have_content("ID: #{shop2.id}")
       expect(page).to_not have_content(shop2.name)
       expect(page).to_not have_content("Stock limit: #{shop2.stock_limit}")
     end
+
   end
 end

--- a/spec/models/game_shop/instance_methods_spec.rb
+++ b/spec/models/game_shop/instance_methods_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe GameShop do
+  describe 'instance methods' do
+    before :each do
+      @shop1 = GameShop.create!(name: "Fred's Games", does_repairs: false, stock_limit: 3)
+      @shop2 = GameShop.create!(name: "Gameville", does_repairs: false, stock_limit: 5)
+      @game1 = @shop1.video_games.create!(name: "DOOM 2016", rating: "M", price: 70, multiplayer: false)
+      @game2 = @shop1.video_games.create!(name: "FIFA 2020", rating: "E", price: 55, multiplayer: true)
+      @game3 = @shop2.video_games.create!(name: "Elden Ring", rating: "M", price: 65, multiplayer: true)
+    end
+
+    context '#total_games_in_stock' do
+      it 'returns the number of games sold by a GameShop' do
+        expect(@shop1.total_games_in_stock).to eq(2)
+        expect(@shop2.total_games_in_stock).to eq(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
When visiting a GameShops#show page, it should display the # of games associated with that particular GameShop