### PR TITLE
refactor: Remove arbitrary 'self.' from GameShop model

### DIFF
--- a/app/models/game_shop.rb
+++ b/app/models/game_shop.rb
@@ -8,11 +8,11 @@ class GameShop < ApplicationRecord
   end
 
   def alphabetized_video_games
-    self.video_games.sort_by { |game| game.name }
+    video_games.order(:name)
   end
 
   def total_games_in_stock
-    self.video_games.count
+    video_games.count
   end
 
   def self.order_by_created_at


### PR DESCRIPTION
Refactored the GameShop model to only use '.self' where needed, as well as replace any ruby code in the model with ActiveRecord methods